### PR TITLE
Extracted the type coercion to a Parameter class to remove some complexity from Tool

### DIFF
--- a/lib/plasma.rb
+++ b/lib/plasma.rb
@@ -11,6 +11,7 @@ require_relative "plasma/cli"
 require_relative "plasma/prompt"
 require_relative "plasma/resource"
 require_relative "plasma/tool"
+require_relative "plasma/parameter"
 require_relative "plasma/storage"
 
 module Plasma

--- a/lib/plasma/parameter.rb
+++ b/lib/plasma/parameter.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Plasma
+  # This class handles type coercion and validation
+  class Parameter
+    def initialize(value, type)
+      @value = value
+      @type = type.to_s.downcase.to_sym
+    end
+
+    def call # rubocop:disable Metrics/MethodLength
+      return if @value.nil?
+
+      case @type
+      when :integer
+        cast_integer
+      when :float
+        cast_float
+      when :boolean
+        cast_boolean
+      when :string
+        cast_string
+      when :array
+        cast_array
+      else
+        @value
+      end
+    end
+
+    alias coerce! call
+
+    private
+
+    def cast_boolean
+      @value == true || @value.to_s.downcase == "true"
+    end
+
+    def cast_integer
+      Integer(@value)
+    rescue StandardError
+      raise ArgumentError, "Invalid integer: #{@value}"
+    end
+
+    def cast_float
+      Float(@value)
+    rescue StandardError
+      raise ArgumentError, "Invalid float: #{@value}"
+    end
+
+    def cast_string
+      @value.to_s
+    end
+
+    def cast_array
+      return @value if @value.is_a?(Array)
+
+      raise ArgumentError, "Invalid array: #{@value}" unless @value.is_a?(String)
+
+      begin
+        parsed = JSON.parse(@value)
+        raise ArgumentError, "Invalid array: #{@value}" unless parsed.is_a?(Array)
+
+        parsed
+      rescue JSON::ParserError
+        raise ArgumentError, "Invalid array: #{@value}"
+      end
+    end
+  end
+end

--- a/lib/plasma/tool.rb
+++ b/lib/plasma/tool.rb
@@ -85,47 +85,9 @@ module Plasma
         value = input[key.to_s]
         raise ArgumentError, "Missing required parameter: #{key}" if config[:required] && value.nil?
 
-        coerced[key] = coerce_value(value, config[:type])
+        coerced[key] = Parameter.new(value, config[:type]).coerce!
       end
       coerced
     end
-
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
-    # This method is deliberately complex as it handles type coercion and validation
-    def coerce_value(value, type)
-      return if value.nil?
-
-      case type.to_s.downcase.to_sym
-      when :integer then begin
-        Integer(value)
-      rescue StandardError
-        raise ArgumentError, "Invalid integer: #{value}"
-      end
-      when :float then begin
-        Float(value)
-      rescue StandardError
-        raise ArgumentError, "Invalid float: #{value}"
-      end
-      when :boolean then !!(value == true || value.to_s.downcase == "true")
-      when :string  then value.to_s
-      when :array
-        if value.is_a?(Array)
-          value
-        elsif value.is_a?(String)
-          begin
-            parsed = JSON.parse(value)
-            raise ArgumentError, "Invalid array: #{value}" unless parsed.is_a?(Array)
-
-            parsed
-          rescue JSON::ParserError
-            raise ArgumentError, "Invalid array: #{value}"
-          end
-        else
-          raise ArgumentError, "Invalid array: #{value}"
-        end
-      else value
-      end
-    end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
   end
 end

--- a/test/test_parameter.rb
+++ b/test/test_parameter.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestParameter < Minitest::Test
+  def setup
+    @klass = Plasma::Parameter
+  end
+
+  def test_returns_nil_for_nil_value
+    assert_nil @klass.new(nil, :any).coerce!
+  end
+
+  def test_coerces_integers
+    assert_equal 42, @klass.new("42", :integer).coerce!
+    assert_equal 0, @klass.new("0", :integer).coerce!
+    assert_equal(-1, @klass.new("-1", :integer).coerce!)
+  end
+
+  def test_failed_integer_coercion
+    assert_raises(ArgumentError) { @klass.new("3.14", :integer).coerce! }
+    assert_raises(ArgumentError) { @klass.new("Wolf 359", :integer).coerce! }
+  end
+
+  def test_coerces_floats
+    assert_in_delta(3.14, @klass.new("3.14", :float).coerce!)
+    assert_in_delta(0.0, @klass.new("0", :float).coerce!)
+    assert_in_delta(-1.5, @klass.new("-1.5", :float).coerce!)
+  end
+
+  def test_failed_float_coercion
+    assert_raises(ArgumentError) { @klass.new("1.0f", :float).coerce! }
+    assert_raises(ArgumentError) { @klass.new("NCC-1701", :float).coerce! }
+  end
+
+  def test_coerces_booleans # rubocop:disable Metrics/AbcSize
+    assert @klass.new(true, :boolean).coerce!
+    assert @klass.new("true", :boolean).coerce!
+    assert @klass.new("TRUE", :boolean).coerce!
+    refute @klass.new(false, :boolean).coerce!
+    refute @klass.new("false", :boolean).coerce!
+    refute @klass.new("FALSE", :boolean).coerce!
+  end
+
+  def test_coerces_strings
+    assert_equal "Hello, World!", @klass.new("Hello, World!", :string).coerce!
+    assert_equal "123", @klass.new(123, :string).coerce!
+    assert_equal "[]", @klass.new([], :string).coerce!
+  end
+
+  def test_coerces_arrays
+    assert_equal [1, 2, 3], @klass.new([1, 2, 3], :array).coerce!
+    assert_equal %w[a b c], @klass.new('["a", "b", "c"]', :array).coerce!
+    assert_equal [1, "two", 3.0], @klass.new("[1, \"two\", 3.0]", :array).coerce!
+  end
+
+  def test_failed_array_coercion
+    assert_raises(ArgumentError) { @klass.new(:nonsense, :array).coerce! }
+    assert_raises(ArgumentError) { @klass.new("[", :array).coerce! }
+  end
+
+  def test_unhandled_types_are_returned_as_is
+    assert_equal :unhandled, @klass.new(:unhandled, :unhandled_type).coerce!
+  end
+end


### PR DESCRIPTION
Extracted the type coercion to a Parameter class to remove some complexity from Tool. Additionally added tests for the different supported parameter types and potential errors. Tool probably shouldn't care about the specifics of Integer parsing.

I'm thinking ultimately about a 'rescue_from' method for tools because I feel like the inputs from LLM can be flaky and unpredictable.